### PR TITLE
fix: Add RED_ALERT_SUMMARY to state in all cases

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -270,6 +270,7 @@ class OwletAPI:
                     "LOW_HR_ALRT": bool(p["LOW_HR_ALRT"]["value"]),
                     "LOW_OX_ALRT": bool(p["LOW_OX_ALRT"]["value"]),
                     "SOCK_DISCON_ALRT": bool(p["SOCK_DISCON_ALRT"]["value"]),
+                    "RED_ALERT_SUMMARY": "",
                     "error": False,
                 }
         return {"dsn": dsn, "error": True}


### PR DESCRIPTION
Found an exception when enabling the owlet monitoring and the sock was already in use.
The RED_ALERT_SUMMARY state key was not populated, giving a key error.
Adding it to the "CHARGE_STATUS" section with an empty string solved the problem.