### PR TITLE
Patch to make compatible with 2022.4

### DIFF
--- a/custom_components/owlet/manifest.json
+++ b/custom_components/owlet/manifest.json
@@ -1,8 +1,8 @@
 {
     "domain": "owlet",
     "name": "Owlet Smart Sock",
-    "version": "0.1.0",
-    "documentation": "https://github.com/jlamendo/ha-sensor.owlet",
+    "version": "0.1.1",
+    "documentation": "https://github.com/RampantRedsFan/ha-sensor.owlet",
     "requirements": [
     "PyJWT", 
     "gcloud",

--- a/custom_components/owlet/sensor.py
+++ b/custom_components/owlet/sensor.py
@@ -311,7 +311,7 @@ class OwletSmartSock(Entity):
         return self.__state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return self.__attributes
 


### PR DESCRIPTION
Attributes property syntax became unsupported. Updated to currently supported property.

Upon acceptance, the "documentaion" property in manifest.json should be changed back to "https://github.com/jlamendo/ha-sensor.owlet"

fixes #13 

Thanks!